### PR TITLE
✨ S3 이미지 업로드 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("io.jsonwebtoken:jjwt-api:$jjwtVersion")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+    implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
+    implementation("com.amazonaws:aws-java-sdk-s3:1.12.741")
 
     runtimeOnly("com.h2database:h2")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:$jjwtVersion")

--- a/src/main/kotlin/com/beanspace/beanspace/api/image/ImageController.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/image/ImageController.kt
@@ -1,0 +1,44 @@
+package com.beanspace.beanspace.api.image
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/api/v1/images")
+class ImageController(
+    private val imageService: ImageService
+) {
+    @PostMapping("/presigned-url")
+    fun getPreSignedUrl(
+        @RequestBody request: PreSignedUrlRequest
+    ): ResponseEntity<PreSignedUrlResponse> {
+        return ResponseEntity
+            .ok(imageService.generatePreSignedUrl(request))
+    }
+
+    @PostMapping
+    fun createPost(
+        @RequestPart request: PostPhotoRequest,
+        @RequestPart images: List<MultipartFile>
+    ): ResponseEntity<PostPhotoResponse> {
+        return ResponseEntity.ok()
+            .body(imageService.createPhotoPost(request, images))
+    }
+
+    @PutMapping("/{photoPostId}")
+    fun updatePostImages(
+        @PathVariable photoPostId: Long,
+        @RequestPart request: List<PhotoUpdateRequest>,
+        @RequestPart images: List<MultipartFile>
+    ): ResponseEntity<PostPhotoResponse> {
+        val updatedPost = imageService.updatePostImages(photoPostId, request, images)
+        return ResponseEntity.ok(updatedPost)
+    }
+}

--- a/src/main/kotlin/com/beanspace/beanspace/api/image/ImageService.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/image/ImageService.kt
@@ -1,0 +1,143 @@
+package com.beanspace.beanspace.api.image
+
+import com.beanspace.beanspace.domain.image.model.Image
+import com.beanspace.beanspace.domain.image.model.ImageType
+import com.beanspace.beanspace.domain.image.model.PhotoPost
+import com.beanspace.beanspace.domain.image.repository.ImageRepository
+import com.beanspace.beanspace.domain.image.repository.PhotoPostRepository
+import com.beanspace.beanspace.infra.s3.S3Service
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+
+@Service
+class ImageService(
+    val imageRepository: ImageRepository,
+    val photoPostRepository: PhotoPostRepository,
+    val s3Service: S3Service
+) {
+    fun generatePreSignedUrl(request: PreSignedUrlRequest): PreSignedUrlResponse {
+        val preSignedUrl = s3Service.generatePreSignedUrl(request.fileName, request.contentType, ImageType.SPACE)
+        return PreSignedUrlResponse(preSignedUrl)
+    }
+
+    @Transactional
+    fun createPhotoPost(request: PostPhotoRequest, images: List<MultipartFile>): PostPhotoResponse {
+        // try - catch 이용해서 여러 이미지 파일 업로드 중 하나가 실패하더라도 S3에 이미 올라간 이미지가 삭제되도록 작성
+
+        val uploadedUrls = mutableListOf<String>()
+
+        try {
+            images.forEach { multipartFile ->
+                val imageUrl = s3Service.uploadFile(multipartFile, ImageType.SPACE)
+                uploadedUrls.add(imageUrl)
+            }
+
+            val photoPost = photoPostRepository.save(PhotoPost(title = request.title, content = request.content))
+
+            uploadedUrls.forEachIndexed { index, imageUrl ->
+                imageRepository.save(
+                    Image(
+                        type = ImageType.SPACE,
+                        imageUrl = imageUrl,
+                        contentId = photoPost.id!!,
+                        orderIndex = index
+                    )
+                )
+            }
+
+            return PostPhotoResponse(
+                title = photoPost.title,
+                content = photoPost.content,
+                imageUrlList = imageRepository.findAllByContentIdAndTypeOrderByOrderIndexAsc(
+                    photoPost.id!!,
+                    ImageType.SPACE
+                ).map { it.imageUrl }
+            )
+        } catch (e: Exception) {
+
+            uploadedUrls.forEach { url ->
+                try {
+                    s3Service.deleteFile("spaces/" + url.substringAfterLast('/'))
+                } catch (deleteException: Exception) {
+                    throw Exception("파일 삭제에 실패하였습니다: $url. 에러 메시지: ${deleteException.message}")
+                }
+            }
+
+            throw e
+        }
+    }
+
+    @Transactional
+    fun updatePostImages(
+        photoPostId: Long,
+        request: List<PhotoUpdateRequest>,
+        files: List<MultipartFile>
+    ): PostPhotoResponse {
+        // 중간에 이미지 업로드 실패시 복구시 적용이 필요함
+
+        val photoPost = photoPostRepository.findByIdOrNull(photoPostId) ?: throw RuntimeException("못 찾음")
+
+        val existingImages = imageRepository.findByContentIdOrderByOrderIndex(photoPostId)
+
+        val fileMap = files.associateBy { it.originalFilename }
+
+        request.forEach { photoUpdateRequest ->
+            when {
+                // 기존에 없던 새로운 이미지
+                photoUpdateRequest.photoId == null && photoUpdateRequest.fileName != null -> {
+                    val file = fileMap[photoUpdateRequest.fileName]
+                        ?: throw IllegalArgumentException("해당 파일 찾을 수 없음: ${photoUpdateRequest.fileName}")
+                    val imageUrl = s3Service.uploadFile(file, ImageType.SPACE)
+                    imageRepository.save(
+                        Image(
+                            type = ImageType.SPACE,
+                            imageUrl = imageUrl,
+                            contentId = photoPostId,
+                            orderIndex = photoUpdateRequest.orderIndex
+                        )
+                    )
+                }
+                // 기존에 있던 이미지 순서 바꾸기
+                photoUpdateRequest.photoId != null -> {
+                    val existingImage = existingImages.find { it.id == photoUpdateRequest.photoId }
+                        ?: throw RuntimeException("못 찾음")
+                    existingImage.orderIndex = photoUpdateRequest.orderIndex
+
+                    // fileName이 DTO에 담겨져 보내졌으면 파일 교체
+                    if (photoUpdateRequest.fileName != null) {
+                        val file = fileMap[photoUpdateRequest.fileName]
+                            ?: throw IllegalArgumentException("해당 파일 찾을 수 없음: ${photoUpdateRequest.fileName}")
+                        val newImageUrl = s3Service.uploadFile(file, ImageType.SPACE)
+
+                        // 이전 이미지 S3에서 제거
+                        s3Service.deleteFile("spaces/" + existingImage.imageUrl.substringAfterLast('/'))
+
+                        existingImage.imageUrl = newImageUrl
+                    }
+
+                    imageRepository.save(existingImage)
+                }
+                // 아마도 클라이언트에서 보낸 값이 잘못 됨
+                else -> throw IllegalArgumentException("유효하지 않은 이미지 수정 요청입니다")
+            }
+        }
+
+        // Request에 없는 이미지 삭제
+        val requestPhotoIds = request.mapNotNull { it.photoId }.toSet()
+        existingImages.filter { it.id !in requestPhotoIds }.forEach { image ->
+            s3Service.deleteFile(image.imageUrl)
+            imageRepository.delete(image)
+        }
+
+        return PostPhotoResponse(
+            title = photoPost.title,
+            content = photoPost.content,
+            imageUrlList = imageRepository.findAllByContentIdAndTypeOrderByOrderIndexAsc(
+                photoPost.id!!,
+                ImageType.SPACE
+            ).map { it.imageUrl }
+        )
+    }
+}

--- a/src/main/kotlin/com/beanspace/beanspace/api/image/PhotoUpdateRequest.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/image/PhotoUpdateRequest.kt
@@ -1,0 +1,7 @@
+package com.beanspace.beanspace.api.image
+
+data class PhotoUpdateRequest(
+    val photoId: Long?, // 새로운 이미지인 경우 null
+    val orderIndex: Int,
+    val fileName: String? // 수정하지 않을 이미지는 null
+)

--- a/src/main/kotlin/com/beanspace/beanspace/api/image/PostPhotoRequest.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/image/PostPhotoRequest.kt
@@ -1,0 +1,6 @@
+package com.beanspace.beanspace.api.image
+
+data class PostPhotoRequest(
+    val title: String,
+    val content: String
+)

--- a/src/main/kotlin/com/beanspace/beanspace/api/image/PostPhotoResponse.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/image/PostPhotoResponse.kt
@@ -1,0 +1,7 @@
+package com.beanspace.beanspace.api.image
+
+data class PostPhotoResponse(
+    val title: String,
+    val content: String,
+    val imageUrlList: List<String>
+)

--- a/src/main/kotlin/com/beanspace/beanspace/api/image/PreSignedUrlRequest.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/image/PreSignedUrlRequest.kt
@@ -1,0 +1,6 @@
+package com.beanspace.beanspace.api.image
+
+data class PreSignedUrlRequest(
+    val fileName: String,
+    val contentType: String
+)

--- a/src/main/kotlin/com/beanspace/beanspace/api/image/PreSignedUrlResponse.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/image/PreSignedUrlResponse.kt
@@ -1,0 +1,5 @@
+package com.beanspace.beanspace.api.image
+
+data class PreSignedUrlResponse(
+    val preSignedUrl: String
+)

--- a/src/main/kotlin/com/beanspace/beanspace/domain/image/model/Image.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/image/model/Image.kt
@@ -1,0 +1,32 @@
+package com.beanspace.beanspace.domain.image.model
+
+import com.beanspace.beanspace.domain.common.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "image")
+data class Image(
+    @Enumerated(EnumType.STRING)
+    val type: ImageType,
+
+    @Column
+    var imageUrl: String,
+
+    @Column
+    val contentId: Long,
+
+    @Column
+    var orderIndex: Int = 0,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+) : BaseTimeEntity()
+

--- a/src/main/kotlin/com/beanspace/beanspace/domain/image/model/ImageType.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/image/model/ImageType.kt
@@ -1,0 +1,5 @@
+package com.beanspace.beanspace.domain.image.model
+
+enum class ImageType {
+    PROFILE, REVIEW, SPACE
+}

--- a/src/main/kotlin/com/beanspace/beanspace/domain/image/model/PhotoPost.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/image/model/PhotoPost.kt
@@ -1,0 +1,22 @@
+package com.beanspace.beanspace.domain.image.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "photo_post")
+class PhotoPost(
+    @Column
+    val title: String,
+
+    @Column
+    val content: String
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null
+}

--- a/src/main/kotlin/com/beanspace/beanspace/domain/image/repository/ImageRepository.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/image/repository/ImageRepository.kt
@@ -1,0 +1,10 @@
+package com.beanspace.beanspace.domain.image.repository
+
+import com.beanspace.beanspace.domain.image.model.Image
+import com.beanspace.beanspace.domain.image.model.ImageType
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ImageRepository : JpaRepository<Image, Long> {
+    fun findAllByContentIdAndTypeOrderByOrderIndexAsc(contentId: Long, contentType: ImageType): List<Image>
+    fun findByContentIdOrderByOrderIndex(contentId: Long): List<Image>
+}

--- a/src/main/kotlin/com/beanspace/beanspace/domain/image/repository/PhotoPostRepository.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/image/repository/PhotoPostRepository.kt
@@ -1,0 +1,6 @@
+package com.beanspace.beanspace.domain.image.repository
+
+import com.beanspace.beanspace.domain.image.model.PhotoPost
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PhotoPostRepository : JpaRepository<PhotoPost, Long>

--- a/src/main/kotlin/com/beanspace/beanspace/infra/s3/S3Config.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/infra/s3/S3Config.kt
@@ -1,0 +1,27 @@
+package com.beanspace.beanspace.infra.s3
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class S3Config(
+    @Value("\${cloud.aws.credentials.access-key}") val accessKey: String,
+    @Value("\${cloud.aws.credentials.secret-key}") val secretKey: String,
+    @Value("\${cloud.aws.region.static}") val region: String
+) {
+    @Bean
+    fun amazonS3Client(): AmazonS3Client {
+        val credentials = BasicAWSCredentials(accessKey, secretKey)
+
+        return AmazonS3ClientBuilder
+            .standard()
+            .withRegion(region)
+            .withCredentials(AWSStaticCredentialsProvider(credentials))
+            .build() as AmazonS3Client
+    }
+}

--- a/src/main/kotlin/com/beanspace/beanspace/infra/s3/S3Service.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/infra/s3/S3Service.kt
@@ -5,7 +5,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.beanspace.beanspace.domain.exception.InvalidImageException
-import com.beanspace.beanspace.domain.photo.model.ImageType
+import com.beanspace.beanspace.domain.image.model.ImageType
 import com.beanspace.beanspace.infra.s3.imagevalidator.ImageValidator
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/com/beanspace/beanspace/infra/s3/S3Service.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/infra/s3/S3Service.kt
@@ -1,0 +1,86 @@
+package com.beanspace.beanspace.infra.s3
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.beanspace.beanspace.domain.exception.InvalidImageException
+import com.beanspace.beanspace.domain.photo.model.ImageType
+import com.beanspace.beanspace.infra.s3.imagevalidator.ImageValidator
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.multipart.MultipartFile
+import java.io.ByteArrayInputStream
+import java.util.UUID
+import javax.imageio.ImageIO
+
+@Component
+class S3Service(
+    @Value("\${cloud.aws.s3.bucket}")
+    private val bucket: String,
+    private val amazonS3: AmazonS3,
+    private val imageValidator: ImageValidator
+) {
+    fun uploadFile(file: MultipartFile, imageType: ImageType): String {
+        val validationResult = imageValidator.isValidImage(file)
+
+        if (!validationResult.isValid) {
+            throw InvalidImageException("${file.originalFilename ?: "알수 없는 파일"}: ${validationResult.reason}")
+        }
+
+        val directory = when (imageType) {
+            ImageType.PROFILE -> "profiles"
+            ImageType.REVIEW -> "reviews"
+            ImageType.SPACE -> "spaces"
+        }
+
+        val filename = "${UUID.randomUUID()}-${file.originalFilename}"
+
+        val key = "$directory/$filename"
+
+        val metadata = ObjectMetadata().apply {
+            contentType = determineContentType(file)
+            contentLength = file.size
+            contentDisposition = "inline"
+        }
+
+        amazonS3.putObject(bucket, key, file.inputStream, metadata)
+
+        return amazonS3.getUrl(bucket, key).toString()
+    }
+
+    fun deleteFile(fileUrl: String) {
+        amazonS3.deleteObject(bucket, fileUrl.substringAfterLast('/'))
+    }
+
+    private fun determineContentType(file: MultipartFile): String {
+        val contentType = file.contentType
+
+        return if (contentType.isNullOrBlank() || contentType == "application/octet-stream") {
+            determineContentTypeByExtension(file.originalFilename)
+        } else {
+            contentType
+        }
+    }
+
+    private fun determineContentTypeByExtension(filename: String?): String {
+        return when (filename?.substringAfterLast('.', "")?.lowercase()) {
+            "jpg", "jpeg" -> "image/jpeg"
+            "png" -> "image/png"
+            "gif" -> "image/gif"
+            "webp" -> "image/webp"
+            "svg" -> "image/svg+xml"
+            "bmp" -> "image/bmp"
+            "tiff", "tif" -> "image/tiff"
+            else -> "application/octet-stream"
+        }
+    }
+
+    private fun isValidImage(bytes: ByteArray): Boolean {
+        return try {
+            val inputStream = ByteArrayInputStream(bytes)
+            val bufferedImage = ImageIO.read(inputStream)
+            bufferedImage != null
+        } catch (e: Exception) {
+            false
+        }
+    }
+}

--- a/src/main/kotlin/com/beanspace/beanspace/infra/s3/imagevalidator/ImageValidator.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/infra/s3/imagevalidator/ImageValidator.kt
@@ -7,16 +7,18 @@ import javax.imageio.ImageIO
 
 @Component
 class ImageValidator {
+    // 허용되는 이미지 확장자 목록
     private val allowedExtensions = listOf(
-        "jpg", "jpeg", "png", "gif", "bmp", "webp", "tiff", "tif", "svg"
+        "jpg", "jpeg", "png", "gif", "webp", "jfif"
     )
 
+    // 허용되는 MIME 타입 목록
     private val allowedMimeTypes = listOf(
-        "image/jpeg", "image/png", "image/gif", "image/bmp",
-        "image/webp", "image/tiff", "image/svg+xml"
+        "image/jpeg", "image/png", "image/gif", "image/webp"
     )
 
-    private val maxFileSizeBytes = 10 * 1024 * 1024 // 10 MB
+    // 허용되는 최대 이미지 용량 (application.yml 에도 최대 파일 크기가 따로 설정되어있음)
+    private val maxFileSizeBytes = 10 * 1024 * 1024 // 10 메가 바이트
 
     fun isValidImage(file: MultipartFile): ValidationResult {
         val extensionValid = isValidExtension(file.originalFilename)
@@ -27,10 +29,10 @@ class ImageValidator {
             return ValidationResult(
                 isValid = false,
                 reason = buildString {
-                    if (!extensionValid) append("Invalid file extension. ")
-                    if (!mimeTypeValid) append("Invalid MIME type. ")
-                    if (!fileSizeValid) append("File size exceeds limit. ")
-                }.trim()
+                    if (!extensionValid) append("지원하지 않는 이미지 확장자입니다")
+                    if (!mimeTypeValid) append("지원하지 않는 MIME 타입입니다")
+                    if (!fileSizeValid) append("10MB 이상의 이미지를 업로드할 수 없습니다")
+                }
             )
         }
 
@@ -53,15 +55,16 @@ class ImageValidator {
 
     private fun isValidImageContent(bytes: ByteArray): ValidationResult {
         return try {
+            // 이미지의 바이트 데이터를 입력 스트림으로 변환
             val inputStream = ByteArrayInputStream(bytes)
 
-            val bufferedImage =
-                ImageIO.read(inputStream) ?: return ValidationResult(false, "Unable to read image content.")
+            // 실제 이미지 파일인지 검증
+            ImageIO.read(inputStream) ?: return ValidationResult(false, "이미지를 읽을 수 없습니다")
 
-
-            ValidationResult(true, "Image is valid.")
+            ValidationResult(true, "이미지가 유효합니다")
         } catch (e: Exception) {
-            ValidationResult(false, "Error processing image: ${e.message}")
+            // 이미지 처리 중 오류 발생 시
+            ValidationResult(false, "이미지를 처리하는 중 오류가 발생하였습니다: ${e.message}")
         }
     }
 }

--- a/src/main/kotlin/com/beanspace/beanspace/infra/s3/imagevalidator/ImageValidator.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/infra/s3/imagevalidator/ImageValidator.kt
@@ -1,0 +1,67 @@
+package com.beanspace.beanspace.infra.s3.imagevalidator
+
+import org.springframework.stereotype.Component
+import org.springframework.web.multipart.MultipartFile
+import java.io.ByteArrayInputStream
+import javax.imageio.ImageIO
+
+@Component
+class ImageValidator {
+    private val allowedExtensions = listOf(
+        "jpg", "jpeg", "png", "gif", "bmp", "webp", "tiff", "tif", "svg"
+    )
+
+    private val allowedMimeTypes = listOf(
+        "image/jpeg", "image/png", "image/gif", "image/bmp",
+        "image/webp", "image/tiff", "image/svg+xml"
+    )
+
+    private val maxFileSizeBytes = 10 * 1024 * 1024 // 10 MB
+
+    fun isValidImage(file: MultipartFile): ValidationResult {
+        val extensionValid = isValidExtension(file.originalFilename)
+        val mimeTypeValid = isValidMimeType(file.contentType)
+        val fileSizeValid = isValidFileSize(file.size)
+
+        if (!extensionValid || !mimeTypeValid || !fileSizeValid) {
+            return ValidationResult(
+                isValid = false,
+                reason = buildString {
+                    if (!extensionValid) append("Invalid file extension. ")
+                    if (!mimeTypeValid) append("Invalid MIME type. ")
+                    if (!fileSizeValid) append("File size exceeds limit. ")
+                }.trim()
+            )
+        }
+
+        return isValidImageContent(file.bytes)
+    }
+
+    private fun isValidExtension(filename: String?): Boolean {
+        if (filename == null) return false
+        val extension = filename.substringAfterLast('.', "").lowercase()
+        return extension in allowedExtensions
+    }
+
+    private fun isValidMimeType(mimeType: String?): Boolean {
+        return mimeType in allowedMimeTypes
+    }
+
+    private fun isValidFileSize(sizeBytes: Long): Boolean {
+        return sizeBytes <= maxFileSizeBytes
+    }
+
+    private fun isValidImageContent(bytes: ByteArray): ValidationResult {
+        return try {
+            val inputStream = ByteArrayInputStream(bytes)
+
+            val bufferedImage =
+                ImageIO.read(inputStream) ?: return ValidationResult(false, "Unable to read image content.")
+
+
+            ValidationResult(true, "Image is valid.")
+        } catch (e: Exception) {
+            ValidationResult(false, "Error processing image: ${e.message}")
+        }
+    }
+}

--- a/src/main/kotlin/com/beanspace/beanspace/infra/s3/imagevalidator/ValidationResult.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/infra/s3/imagevalidator/ValidationResult.kt
@@ -1,0 +1,3 @@
+package com.beanspace.beanspace.infra.s3.imagevalidator
+
+data class ValidationResult(val isValid: Boolean, val reason: String)


### PR DESCRIPTION
## 요약
S3 이용 이미지 업로드 구현을 완료하였습니다.


## 작업 사항
S3 Service를 통해 이미지 파일 업로드, 삭제, PresignedUrl 발급이 가능합니다.
ImageController에 있는 URI를 통해서 PresignedUrl을 발급받을 수 있습니다.
MultiPartFile 이용해서 다중 이미지 업로드 구현하는 부분도 예시로 만들어놓았습니다. (나중에 삭제 예정)

---

### 해결한 이슈

closes: #3 
