### PR TITLE
:sparkles: 멤버가 보유한 쿠폰 목록 조회 구현

### DIFF
--- a/src/main/kotlin/com/beanspace/beanspace/api/coupon/dto/UserCouponResponse.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/coupon/dto/UserCouponResponse.kt
@@ -1,0 +1,26 @@
+package com.beanspace.beanspace.api.coupon.dto
+
+import com.beanspace.beanspace.domain.coupon.model.UserCoupon
+import java.time.LocalDateTime
+
+data class UserCouponResponse(
+    val name: String,
+    val discountRate: Int,
+    val maxDiscount: Int,
+    val expirationAt: LocalDateTime,
+    val usedAt: LocalDateTime?,
+    val userCouponId: Long
+) {
+    companion object {
+        fun from(userCoupon: UserCoupon): UserCouponResponse {
+            return UserCouponResponse(
+                name = userCoupon.coupon.name,
+                discountRate = userCoupon.coupon.discountRate,
+                maxDiscount = userCoupon.coupon.maxDiscount,
+                expirationAt = userCoupon.coupon.expirationAt,
+                usedAt = userCoupon.usedAt,
+                userCouponId = userCoupon.id!!
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/beanspace/beanspace/api/member/MemberController.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/member/MemberController.kt
@@ -1,5 +1,6 @@
 package com.beanspace.beanspace.api.member
 
+import com.beanspace.beanspace.api.coupon.dto.UserCouponResponse
 import com.beanspace.beanspace.api.member.dto.MemberProfileResponse
 import com.beanspace.beanspace.api.member.dto.UpdateProfileRequest
 import com.beanspace.beanspace.api.space.dto.SpaceResponse
@@ -8,7 +9,11 @@ import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1/members")
@@ -38,5 +43,11 @@ class MemberController(
     fun getWishListedSpaceList(): ResponseEntity<List<SpaceResponse>> {
         return ResponseEntity
             .ok(memberService.getWishListedSpaceList(/* 인증정보 */))
+    }
+
+    @GetMapping("/couponList")
+    fun getMemberCouponList(@AuthenticationPrincipal userPrincipal: UserPrincipal): ResponseEntity<List<UserCouponResponse>> {
+        return ResponseEntity
+            .ok(memberService.getCouponList(userPrincipal))
     }
 }

--- a/src/main/kotlin/com/beanspace/beanspace/api/member/MemberService.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/member/MemberService.kt
@@ -38,11 +38,9 @@ class MemberService(
         // 유저가 찜한 공간 리스트 조회하기
         TODO()
     }
-
+    
     fun getCouponList(userPrincipal: UserPrincipal): List<UserCouponResponse> {
-        return userCouponRepository.findAllByMemberId(userPrincipal.id)
+        return userCouponRepository.getMemberCouponList(userPrincipal)
             .map { UserCouponResponse.from(it) }
-            .let { response -> response.sortedBy { it.expirationAt } }
-        // ↑ 쿠폰을 만료에 가까운 순서대로 정렬
     }
 }

--- a/src/main/kotlin/com/beanspace/beanspace/api/member/MemberService.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/member/MemberService.kt
@@ -38,9 +38,9 @@ class MemberService(
         // 유저가 찜한 공간 리스트 조회하기
         TODO()
     }
-    
+
     fun getCouponList(userPrincipal: UserPrincipal): List<UserCouponResponse> {
-        return userCouponRepository.getMemberCouponList(userPrincipal)
+        return userCouponRepository.getMemberCouponList(userPrincipal.id)
             .map { UserCouponResponse.from(it) }
     }
 }

--- a/src/main/kotlin/com/beanspace/beanspace/api/member/MemberService.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/member/MemberService.kt
@@ -1,11 +1,12 @@
 package com.beanspace.beanspace.api.member
 
+import com.beanspace.beanspace.api.coupon.dto.UserCouponResponse
 import com.beanspace.beanspace.api.member.dto.MemberProfileResponse
 import com.beanspace.beanspace.api.member.dto.UpdateProfileRequest
 import com.beanspace.beanspace.api.space.dto.SpaceResponse
+import com.beanspace.beanspace.domain.coupon.repository.UserCouponRepository
 import com.beanspace.beanspace.domain.exception.ModelNotFoundException
 import com.beanspace.beanspace.domain.member.repository.MemberRepository
-import com.beanspace.beanspace.domain.space.repository.SpaceRepository
 import com.beanspace.beanspace.infra.security.dto.UserPrincipal
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -14,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class MemberService(
     private val memberRepository: MemberRepository,
-    private val spaceRepository: SpaceRepository,
+    private val userCouponRepository: UserCouponRepository,
 ) {
 
     @Transactional
@@ -24,15 +25,13 @@ class MemberService(
             ?.also { it.updateProfile(nickname = request.nickname, email = request.email) }
             ?.let { MemberProfileResponse.fromEntity(it) }
             ?: throw ModelNotFoundException("Member", principal.id)
-
     }
 
     fun getProfile(principal: UserPrincipal): MemberProfileResponse {
-        
+
         return memberRepository.findByIdOrNull(principal.id)
             ?.let { MemberProfileResponse.fromEntity(it) }
             ?: throw ModelNotFoundException("Member", principal.id)
-
     }
 
     fun getWishListedSpaceList(/* 인증 정보 */): List<SpaceResponse> {
@@ -40,4 +39,10 @@ class MemberService(
         TODO()
     }
 
+    fun getCouponList(userPrincipal: UserPrincipal): List<UserCouponResponse> {
+        return userCouponRepository.findAllByMemberId(userPrincipal.id)
+            .map { UserCouponResponse.from(it) }
+            .let { response -> response.sortedBy { it.expirationAt } }
+        // ↑ 쿠폰을 만료에 가까운 순서대로 정렬
+    }
 }

--- a/src/main/kotlin/com/beanspace/beanspace/domain/coupon/repository/CustomUserCouponRepository.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/coupon/repository/CustomUserCouponRepository.kt
@@ -1,8 +1,7 @@
 package com.beanspace.beanspace.domain.coupon.repository
 
 import com.beanspace.beanspace.domain.coupon.model.UserCoupon
-import com.beanspace.beanspace.infra.security.dto.UserPrincipal
 
 interface CustomUserCouponRepository {
-    fun getMemberCouponList(userPrincipal: UserPrincipal): List<UserCoupon>
+    fun getMemberCouponList(memberId: Long): List<UserCoupon>
 }

--- a/src/main/kotlin/com/beanspace/beanspace/domain/coupon/repository/CustomUserCouponRepository.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/coupon/repository/CustomUserCouponRepository.kt
@@ -1,0 +1,8 @@
+package com.beanspace.beanspace.domain.coupon.repository
+
+import com.beanspace.beanspace.domain.coupon.model.UserCoupon
+import com.beanspace.beanspace.infra.security.dto.UserPrincipal
+
+interface CustomUserCouponRepository {
+    fun getMemberCouponList(userPrincipal: UserPrincipal): List<UserCoupon>
+}

--- a/src/main/kotlin/com/beanspace/beanspace/domain/coupon/repository/UserCouponRepository.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/coupon/repository/UserCouponRepository.kt
@@ -3,7 +3,6 @@ package com.beanspace.beanspace.domain.coupon.repository
 import com.beanspace.beanspace.domain.coupon.model.UserCoupon
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface UserCouponRepository : JpaRepository<UserCoupon, Long> {
+interface UserCouponRepository : JpaRepository<UserCoupon, Long>, CustomUserCouponRepository {
     fun existsByCouponIdAndMemberId(couponId: Long, memberId: Long): Boolean
-    fun findAllByMemberId(memberId: Long): List<UserCoupon>
 }

--- a/src/main/kotlin/com/beanspace/beanspace/domain/coupon/repository/UserCouponRepository.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/coupon/repository/UserCouponRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserCouponRepository : JpaRepository<UserCoupon, Long> {
     fun existsByCouponIdAndMemberId(couponId: Long, memberId: Long): Boolean
+    fun findAllByMemberId(memberId: Long): List<UserCoupon>
 }

--- a/src/main/kotlin/com/beanspace/beanspace/domain/coupon/repository/UserCouponRepositoryImpl.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/coupon/repository/UserCouponRepositoryImpl.kt
@@ -4,19 +4,18 @@ import com.beanspace.beanspace.domain.coupon.model.QCoupon
 import com.beanspace.beanspace.domain.coupon.model.QUserCoupon
 import com.beanspace.beanspace.domain.coupon.model.UserCoupon
 import com.beanspace.beanspace.infra.querydsl.QueryDslConfig
-import com.beanspace.beanspace.infra.security.dto.UserPrincipal
 
 class UserCouponRepositoryImpl : CustomUserCouponRepository, QueryDslConfig() {
 
     val userCoupon = QUserCoupon.userCoupon
     val coupon = QCoupon.coupon
 
-    override fun getMemberCouponList(userPrincipal: UserPrincipal): List<UserCoupon> {
+    override fun getMemberCouponList(memberId: Long): List<UserCoupon> {
         return queryFactory()
             .selectFrom(userCoupon)
             .leftJoin(userCoupon.coupon, coupon)
             .fetchJoin()
-            .where(userCoupon.member.id.eq(userPrincipal.id))
+            .where(userCoupon.member.id.eq(memberId))
             .orderBy(userCoupon.coupon.expirationAt.asc())
             .fetch()
     }

--- a/src/main/kotlin/com/beanspace/beanspace/domain/coupon/repository/UserCouponRepositoryImpl.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/coupon/repository/UserCouponRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.beanspace.beanspace.domain.coupon.repository
+
+import com.beanspace.beanspace.domain.coupon.model.QCoupon
+import com.beanspace.beanspace.domain.coupon.model.QUserCoupon
+import com.beanspace.beanspace.domain.coupon.model.UserCoupon
+import com.beanspace.beanspace.infra.querydsl.QueryDslConfig
+import com.beanspace.beanspace.infra.security.dto.UserPrincipal
+
+class UserCouponRepositoryImpl : CustomUserCouponRepository, QueryDslConfig() {
+
+    val userCoupon = QUserCoupon.userCoupon
+    val coupon = QCoupon.coupon
+
+    override fun getMemberCouponList(userPrincipal: UserPrincipal): List<UserCoupon> {
+        return queryFactory()
+            .selectFrom(userCoupon)
+            .leftJoin(userCoupon.coupon, coupon)
+            .fetchJoin()
+            .where(userCoupon.member.id.eq(userPrincipal.id))
+            .orderBy(userCoupon.coupon.expirationAt.asc())
+            .fetch()
+    }
+}


### PR DESCRIPTION
## 요약

멤버가 보유한 쿠폰 목록 조회 기능을 구현했습니다

## 작업 사항

멤버 본인이 보유한 쿠폰 목록을 조회하는 기능을 구현했습니다.
모든 사용한 쿠폰, 만료된 쿠폰, 사용가능한 쿠폰 구분없이 모두 내보냅니다.
만료일을 기준으로 정렬되어있습니다. (만료일이 지난 것이 먼저 뜨고, 아직 사용하지 않은 쿠폰은 만료일이 가까운 순으로 정렬 됩니다.)
사용된 쿠폰은 Reponse의 usedAt으로 구분 가능합니다 

### 해결한 이슈

closes: #47
