### PR TITLE
:sparkles: 프로필 이미지 업로드, 수정, 삭제 구현

### DIFF
--- a/src/main/kotlin/com/beanspace/beanspace/api/auth/dto/SignUpRequest.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/auth/dto/SignUpRequest.kt
@@ -47,10 +47,10 @@ data class SignUpRequest(
         passwordEncoder: PasswordEncoder
     ): Member {
         return Member(
-            phoneNumber = this.phoneNumber,
-            email = this.email,
-            password = passwordEncoder.encode(this.password),
-            nickname = this.nickname,
+            phoneNumber = phoneNumber,
+            email = email,
+            password = passwordEncoder.encode(password),
+            nickname = nickname,
             profileImageUrl = profileImageUrl
         )
     }

--- a/src/main/kotlin/com/beanspace/beanspace/api/auth/dto/SignUpRequest.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/auth/dto/SignUpRequest.kt
@@ -40,15 +40,18 @@ data class SignUpRequest(
     )
     val email: String,
 
-    ) {
+    val profileImageUrl: String?
+
+) {
     fun toEntity(
         passwordEncoder: PasswordEncoder
     ): Member {
         return Member(
+            phoneNumber = this.phoneNumber,
             email = this.email,
             password = passwordEncoder.encode(this.password),
             nickname = this.nickname,
-            phoneNumber = this.phoneNumber,
+            profileImageUrl = profileImageUrl
         )
     }
 }

--- a/src/main/kotlin/com/beanspace/beanspace/api/member/MemberService.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/member/MemberService.kt
@@ -28,7 +28,13 @@ class MemberService(
     fun updateProfile(principal: UserPrincipal, request: UpdateProfileRequest): MemberProfileResponse {
 
         return memberRepository.findByIdOrNull(principal.id)
-            ?.also { it.updateProfile(nickname = request.nickname, email = request.email) }
+            ?.also {
+                it.updateProfile(
+                    nickname = request.nickname,
+                    email = request.email,
+                    profileImageUrl = request.profileImageUrl
+                )
+            }
             ?.let { MemberProfileResponse.fromEntity(it) }
             ?: throw ModelNotFoundException("Member", principal.id)
     }

--- a/src/main/kotlin/com/beanspace/beanspace/api/member/dto/MemberProfileResponse.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/member/dto/MemberProfileResponse.kt
@@ -5,14 +5,16 @@ import com.beanspace.beanspace.domain.member.model.Member
 data class MemberProfileResponse(
     val id: Long,
     val email: String,
-    val nickname: String
+    val nickname: String,
+    val profileImageUrl: String?
 ) {
     companion object {
         fun fromEntity(member: Member): MemberProfileResponse {
             return MemberProfileResponse(
                 id = member.id!!,
                 email = member.email,
-                nickname = member.nickname
+                nickname = member.nickname,
+                profileImageUrl = member.profileImageUrl
             )
         }
     }

--- a/src/main/kotlin/com/beanspace/beanspace/api/member/dto/UpdateProfileRequest.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/member/dto/UpdateProfileRequest.kt
@@ -19,5 +19,7 @@ data class UpdateProfileRequest(
         regexp = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$",
         message = "올바른 이메일 형식을 입력해주세요."
     )
-    val email: String
+    val email: String,
+
+    val profileImageUrl: String?
 )

--- a/src/main/kotlin/com/beanspace/beanspace/domain/image/model/ImageType.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/image/model/ImageType.kt
@@ -1,5 +1,5 @@
 package com.beanspace.beanspace.domain.image.model
 
 enum class ImageType {
-    PROFILE, REVIEW, SPACE
+    REVIEW, SPACE
 }

--- a/src/main/kotlin/com/beanspace/beanspace/domain/member/model/Member.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/member/model/Member.kt
@@ -1,8 +1,13 @@
 package com.beanspace.beanspace.domain.member.model
 
 import com.beanspace.beanspace.domain.common.BaseTimeEntity
-import jakarta.persistence.*
-
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
 
 @Entity
 class Member(
@@ -19,6 +24,9 @@ class Member(
     @Column
     var email: String,
 
+    @Column
+    var profileImageUrl: String?,
+
     @Enumerated(EnumType.STRING)
     @Column
     var role: MemberRole = MemberRole.MEMBER,
@@ -28,9 +36,10 @@ class Member(
     var id: Long? = null
 
 ) : BaseTimeEntity() {
-    fun updateProfile(nickname: String, email: String) {
+    fun updateProfile(nickname: String, email: String, profileImageUrl: String?) {
         this.nickname = nickname
         this.email = email
+        this.profileImageUrl = profileImageUrl
     }
 
     fun updateRoleToHost() {


### PR DESCRIPTION
## 요약

Member의 프로필 이미지 업로드, 수정, 삭제 기능을 구현하였습니다.

## 작업 사항

PresignedUrl을 사용한다고 가정하고 클라이언트로부터 url만 받도록 만들었습니다.
Member 엔티티에 Url이 포함되도록 만들었습니다.

---

### 해결한 이슈

closes: #52 
