### PR TITLE
✅ SpaceQueryDslRepository.search() 테스트코드 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,10 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.1")
     testImplementation("org.springframework.security:spring-security-test")
+    testImplementation("com.appmattus.fixture:fixture:1.2.0")
+    testImplementation("com.appmattus.fixture:fixture-kotest:1.2.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/kotlin/com/beanspace/beanspace/domain/space/repository/SpaceQueryDslRepository.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/space/repository/SpaceQueryDslRepository.kt
@@ -10,10 +10,10 @@ import java.time.LocalDate
 interface SpaceQueryDslRepository {
     fun findByStatus(pageable: Pageable, spaceStatus: SpaceStatus): Page<Space>
     fun search(
-        sido: String?,
-        checkIn: LocalDate?,
-        checkOut: LocalDate?,
-        headCount: Int?,
+        sido: String? = null,
+        checkIn: LocalDate? = null,
+        checkOut: LocalDate? = null,
+        headCount: Int? = null,
         pageable: Pageable
     ): Pair<Map<Space?, List<String>>, Long>
 

--- a/src/test/kotlin/com/beanspace/beanspace/domain/space/repository/SpaceQueryDslRepositoryTest.kt
+++ b/src/test/kotlin/com/beanspace/beanspace/domain/space/repository/SpaceQueryDslRepositoryTest.kt
@@ -57,6 +57,11 @@ class SpaceQueryDslRepositoryTest @Autowired constructor(
                             status = fixture(listOf(SpaceStatus.ACTIVE, SpaceStatus.PENDING, SpaceStatus.REJECTED))
                         )
                     spaceRepository.saveAllAndFlush(spaceFixtures)
+
+                    val (contents, totalCount) = spaceRepository.search(pageable = defaultPageable)
+
+                    contents.forEach { it.key?.status shouldBe SpaceStatus.ACTIVE }
+                    totalCount shouldBe spaceFixtures.filter { it.status == SpaceStatus.ACTIVE }.size
                 }
             }
         }
@@ -396,7 +401,7 @@ class SpaceQueryDslRepositoryTest @Autowired constructor(
                     property(Address::sido) { sidoFixture }
                     property(Space::defaultPeople) { minFixture }
                     property(Space::maxPeople) { maxFixture }
-                    property(Space::status) { SpaceStatus.ACTIVE }
+                    property(Space::status) { status }
                     property(Space::host) { host }
                 }
             }

--- a/src/test/kotlin/com/beanspace/beanspace/domain/space/repository/SpaceQueryDslRepositoryTest.kt
+++ b/src/test/kotlin/com/beanspace/beanspace/domain/space/repository/SpaceQueryDslRepositoryTest.kt
@@ -78,14 +78,7 @@ class SpaceQueryDslRepositoryTest @Autowired constructor(
 
                     val keyword = "충청"
 
-                    val searchResult = spaceRepository.search(
-                        sido = keyword,
-                        checkIn = null,
-                        checkOut = null,
-                        headCount = null,
-                        pageable = defaultPageable
-                    )
-                    val (contents, totalCount) = searchResult
+                    val (contents, totalCount) = spaceRepository.search(sido = keyword, pageable = defaultPageable)
 
                     contents.size shouldBeLessThanOrEqual defaultPageable.pageSize
                     contents.forEach {
@@ -112,14 +105,11 @@ class SpaceQueryDslRepositoryTest @Autowired constructor(
                     val reservations = getReservationFixtures(50, guest, space, baseDate)
                     reservationRepository.saveAllAndFlush(reservations)
 
-                    val searchResult = spaceRepository.search(
-                        sido = null,
+                    val (contents, _) = spaceRepository.search(
                         checkIn = LocalDate.of(2024, 7, 1),
-                        checkOut = null,
-                        headCount = null,
                         pageable = defaultPageable
                     )
-                    val (contents, totalCount) = searchResult
+
                     contents.size shouldBe 0
                 }
             }
@@ -138,14 +128,10 @@ class SpaceQueryDslRepositoryTest @Autowired constructor(
                     val reservations = getReservationFixtures(50, guest, space, baseDate)
                     reservationRepository.saveAllAndFlush(reservations)
 
-                    val searchResult = spaceRepository.search(
-                        sido = null,
+                    val (contents, _) = spaceRepository.search(
                         checkIn = LocalDate.of(2024, 7, 3),
-                        checkOut = null,
-                        headCount = null,
                         pageable = defaultPageable
                     )
-                    val (contents, totalCount) = searchResult
                     contents.size shouldNotBe 0
                 }
             }
@@ -166,14 +152,10 @@ class SpaceQueryDslRepositoryTest @Autowired constructor(
                     val reservations = getReservationFixtures(50, guest, space, baseDate)
                     reservationRepository.saveAllAndFlush(reservations)
 
-                    val searchResult = spaceRepository.search(
-                        sido = null,
-                        checkIn = null,
+                    val (contents, _) = spaceRepository.search(
                         checkOut = LocalDate.of(2024, 7, 3),
-                        headCount = null,
                         pageable = defaultPageable
                     )
-                    val (contents, totalCount) = searchResult
                     contents.size shouldBe 0
                 }
             }
@@ -192,14 +174,10 @@ class SpaceQueryDslRepositoryTest @Autowired constructor(
                     val reservations = getReservationFixtures(50, guest, space, baseDate)
                     reservationRepository.saveAllAndFlush(reservations)
 
-                    val searchResult = spaceRepository.search(
-                        sido = null,
-                        checkIn = null,
+                    val (contents, _) = spaceRepository.search(
                         checkOut = LocalDate.of(2024, 7, 4),
-                        headCount = null,
                         pageable = defaultPageable
                     )
-                    val (contents, totalCount) = searchResult
                     contents.size shouldNotBe 0
                 }
             }
@@ -216,14 +194,10 @@ class SpaceQueryDslRepositoryTest @Autowired constructor(
 
                     val headCount = 4
 
-                    val searchResult = spaceRepository.search(
-                        sido = null,
-                        checkIn = null,
-                        checkOut = null,
+                    val (contents, totalCount) = spaceRepository.search(
                         headCount = headCount,
                         pageable = defaultPageable
                     )
-                    val (contents, totalCount) = searchResult
 
                     contents.size shouldBeLessThanOrEqual defaultPageable.pageSize
                     contents.forEach {
@@ -254,14 +228,12 @@ class SpaceQueryDslRepositoryTest @Autowired constructor(
                     val reservations = getReservationFixtures(50, guest, space, baseDate)
                     reservationRepository.saveAllAndFlush(reservations)
 
-                    val searchResult = spaceRepository.search(
-                        sido = null,
+                    val (contents, _) = spaceRepository.search(
                         checkIn = LocalDate.of(2024, 7, 3),
                         checkOut = LocalDate.of(2024, 7, 4),
-                        headCount = null,
                         pageable = defaultPageable
                     )
-                    val (contents, totalCount) = searchResult
+
                     contents.size shouldNotBe 0
                 }
             }
@@ -280,14 +252,12 @@ class SpaceQueryDslRepositoryTest @Autowired constructor(
                     val reservations = getReservationFixtures(50, guest, space, baseDate)
                     reservationRepository.saveAllAndFlush(reservations)
 
-                    val searchResult = spaceRepository.search(
-                        sido = null,
+                    val (contents, _) = spaceRepository.search(
                         checkIn = LocalDate.of(2024, 7, 1),
                         checkOut = LocalDate.of(2024, 7, 4),
-                        headCount = null,
                         pageable = defaultPageable
                     )
-                    val (contents, totalCount) = searchResult
+
                     contents.size shouldBe 0
                 }
             }
@@ -311,14 +281,7 @@ class SpaceQueryDslRepositoryTest @Autowired constructor(
 
                     val pageable = PageRequest.of(0, pageSize)
 
-                    val searchResult = spaceRepository.search(
-                        sido = null,
-                        checkIn = null,
-                        checkOut = null,
-                        headCount = null,
-                        pageable = pageable
-                    )
-                    val (contents, totalCount) = searchResult
+                    val (contents, totalCount) = spaceRepository.search(pageable = pageable)
 
                     contents.size shouldBe pageSize
                     totalCount shouldBe totalSpaceCount
@@ -336,24 +299,8 @@ class SpaceQueryDslRepositoryTest @Autowired constructor(
                     val page1 = PageRequest.of(0, 12)
                     val page2 = PageRequest.of(1, 12)
 
-                    val searchResultOfPage1 = spaceRepository.search(
-                        sido = null,
-                        checkIn = null,
-                        checkOut = null,
-                        headCount = null,
-                        pageable = page1
-                    )
-
-                    val searchResultOfPage2 = spaceRepository.search(
-                        sido = null,
-                        checkIn = null,
-                        checkOut = null,
-                        headCount = null,
-                        pageable = page2
-                    )
-
-                    val (contents1, totalCount1) = searchResultOfPage1
-                    val (contents2, totalCount2) = searchResultOfPage2
+                    val (contents1, _) = spaceRepository.search(pageable = page1)
+                    val (contents2, _) = spaceRepository.search(pageable = page2)
 
                     contents1 shouldNotContainValue contents2
                 }

--- a/src/test/kotlin/com/beanspace/beanspace/domain/space/repository/SpaceQueryDslRepositoryTest.kt
+++ b/src/test/kotlin/com/beanspace/beanspace/domain/space/repository/SpaceQueryDslRepositoryTest.kt
@@ -1,0 +1,427 @@
+package com.beanspace.beanspace.domain.space.repository
+
+import com.appmattus.kotlinfixture.config.range
+import com.appmattus.kotlinfixture.kotlinFixture
+import com.beanspace.beanspace.domain.member.model.Member
+import com.beanspace.beanspace.domain.member.model.MemberRole
+import com.beanspace.beanspace.domain.member.repository.MemberRepository
+import com.beanspace.beanspace.domain.reservation.model.Reservation
+import com.beanspace.beanspace.domain.reservation.repository.ReservationRepository
+import com.beanspace.beanspace.domain.space.model.Address
+import com.beanspace.beanspace.domain.space.model.Space
+import com.beanspace.beanspace.domain.space.model.SpaceStatus
+import com.beanspace.beanspace.infra.querydsl.QueryDslConfig
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.maps.shouldNotContainValue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.test.context.ActiveProfiles
+import java.time.LocalDate
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(value = [QueryDslConfig::class])
+@ActiveProfiles("test")
+class SpaceQueryDslRepositoryTest @Autowired constructor(
+    private val spaceRepository: SpaceRepository,
+    private val reservationRepository: ReservationRepository,
+    private val membersRepository: MemberRepository,
+) : BehaviorSpec({
+
+    context("SpaceQueryDslRepository.search()") {
+
+        beforeEach {
+            reservationRepository.deleteAll()
+            spaceRepository.deleteAll()
+            membersRepository.deleteAll()
+        }
+
+        given("저장된 Space의 status가 각각 다를 때") {
+            `when`("search()시") {
+                then("space.status==SpaceStatus.ACTIVE인 Space만 반환된다.") {
+                    val host = membersRepository.saveAndFlush(defaultHost)
+
+                    val spaceFixtures =
+                        generateSpaceFixtures(
+                            numberOfFixtures = 50,
+                            host = host,
+                            status = fixture(listOf(SpaceStatus.ACTIVE, SpaceStatus.PENDING, SpaceStatus.REJECTED))
+                        )
+                    spaceRepository.saveAllAndFlush(spaceFixtures)
+                }
+            }
+        }
+
+        given("sido로 search()시") {
+            `when`("특정 키워드를 보내면") {
+                then("Space.adress.sido가 키워드를 포함한 Space만 반환된다.") {
+
+                    val host = membersRepository.saveAndFlush(defaultHost)
+
+                    val spaceFixtures =
+                        generateSpaceFixtures(numberOfFixtures = 50, host = host, status = SpaceStatus.ACTIVE)
+                    spaceRepository.saveAllAndFlush(spaceFixtures)
+
+                    val keyword = "충청"
+
+                    val searchResult = spaceRepository.search(
+                        sido = keyword,
+                        checkIn = null,
+                        checkOut = null,
+                        headCount = null,
+                        pageable = defaultPageable
+                    )
+                    val (contents, totalCount) = searchResult
+
+                    contents.size shouldBeLessThanOrEqual defaultPageable.pageSize
+                    contents.forEach {
+                        it.key?.address!!.sido shouldContain keyword
+                    }
+
+                    totalCount shouldBe spaceFixtures.filter { it.address.sido.contains(keyword) }.size
+                }
+            }
+        }
+
+        given("checkIn으로 search()시") {
+            `when`("checkIn 날짜가 이미 reservation이 있는 날짜이면") {
+                then("반환되는 Space가 없어야 한다.") {
+                    val guest = membersRepository.saveAndFlush(defaultGuest)
+                    val host = membersRepository.saveAndFlush(defaultHost)
+
+                    val spaceFixture =
+                        generateSpaceFixtures(numberOfFixtures = 1, host = host, status = SpaceStatus.ACTIVE)
+                    val space = spaceRepository.saveAndFlush(spaceFixture[0])
+
+                    val baseDate = LocalDate.of(2024, 7, 1)
+
+                    val reservations = getReservationFixtures(50, guest, space, baseDate)
+                    reservationRepository.saveAllAndFlush(reservations)
+
+                    val searchResult = spaceRepository.search(
+                        sido = null,
+                        checkIn = LocalDate.of(2024, 7, 1),
+                        checkOut = null,
+                        headCount = null,
+                        pageable = defaultPageable
+                    )
+                    val (contents, totalCount) = searchResult
+                    contents.size shouldBe 0
+                }
+            }
+
+            `when`("checkIn 날짜가 reservation이 없는 날짜이면") {
+                then("반환되는 Space가 있어야 한다.") {
+                    val guest = membersRepository.saveAndFlush(defaultGuest)
+                    val host = membersRepository.saveAndFlush(defaultHost)
+
+                    val spaceFixture =
+                        generateSpaceFixtures(numberOfFixtures = 1, host = host, status = SpaceStatus.ACTIVE)
+                    val space = spaceRepository.saveAndFlush(spaceFixture[0])
+
+                    val baseDate = LocalDate.of(2024, 7, 1)
+
+                    val reservations = getReservationFixtures(50, guest, space, baseDate)
+                    reservationRepository.saveAllAndFlush(reservations)
+
+                    val searchResult = spaceRepository.search(
+                        sido = null,
+                        checkIn = LocalDate.of(2024, 7, 3),
+                        checkOut = null,
+                        headCount = null,
+                        pageable = defaultPageable
+                    )
+                    val (contents, totalCount) = searchResult
+                    contents.size shouldNotBe 0
+                }
+            }
+        }
+
+        given("checkOut으로 search()시") {
+            `when`("checkOut 날짜가 이미 reservation이 있는 날짜이면") {
+                then("반환되는 Space가 없어야 한다.") {
+                    val guest = membersRepository.saveAndFlush(defaultGuest)
+                    val host = membersRepository.saveAndFlush(defaultHost)
+
+                    val spaceFixture =
+                        generateSpaceFixtures(numberOfFixtures = 1, host = host, status = SpaceStatus.ACTIVE)
+                    val space = spaceRepository.saveAndFlush(spaceFixture[0])
+
+                    val baseDate = LocalDate.of(2024, 7, 1)
+
+                    val reservations = getReservationFixtures(50, guest, space, baseDate)
+                    reservationRepository.saveAllAndFlush(reservations)
+
+                    val searchResult = spaceRepository.search(
+                        sido = null,
+                        checkIn = null,
+                        checkOut = LocalDate.of(2024, 7, 3),
+                        headCount = null,
+                        pageable = defaultPageable
+                    )
+                    val (contents, totalCount) = searchResult
+                    contents.size shouldBe 0
+                }
+            }
+
+            `when`("checkOut 날짜가 reservation이 없는 날짜이면") {
+                then("반환되는 Space가 있어야 한다.") {
+                    val guest = membersRepository.saveAndFlush(defaultGuest)
+                    val host = membersRepository.saveAndFlush(defaultHost)
+
+                    val spaceFixture =
+                        generateSpaceFixtures(numberOfFixtures = 1, host = host, status = SpaceStatus.ACTIVE)
+                    val space = spaceRepository.saveAndFlush(spaceFixture[0])
+
+                    val baseDate = LocalDate.of(2024, 7, 1)
+
+                    val reservations = getReservationFixtures(50, guest, space, baseDate)
+                    reservationRepository.saveAllAndFlush(reservations)
+
+                    val searchResult = spaceRepository.search(
+                        sido = null,
+                        checkIn = null,
+                        checkOut = LocalDate.of(2024, 7, 4),
+                        headCount = null,
+                        pageable = defaultPageable
+                    )
+                    val (contents, totalCount) = searchResult
+                    contents.size shouldNotBe 0
+                }
+            }
+        }
+
+        given("headCount로 search()시 ") {
+            `when`("defaultPeople <= headCount <= maxPeople") {
+                then("조건을 만족하는 Space만 반환된다.") {
+                    val host = membersRepository.saveAndFlush(defaultHost)
+
+                    val spaceFixture =
+                        generateSpaceFixtures(numberOfFixtures = 50, host = host, status = SpaceStatus.ACTIVE)
+                    spaceRepository.saveAllAndFlush(spaceFixture)
+
+                    val headCount = 4
+
+                    val searchResult = spaceRepository.search(
+                        sido = null,
+                        checkIn = null,
+                        checkOut = null,
+                        headCount = headCount,
+                        pageable = defaultPageable
+                    )
+                    val (contents, totalCount) = searchResult
+
+                    contents.size shouldBeLessThanOrEqual defaultPageable.pageSize
+                    contents.forEach {
+                        it.key!!.defaultPeople shouldBeLessThanOrEqual headCount
+                        it.key!!.maxPeople shouldBeGreaterThanOrEqual headCount
+                    }
+
+                    totalCount shouldBe spaceFixture.filter {
+                        it.defaultPeople <= headCount && headCount <= it.maxPeople
+                    }.size
+
+                }
+            }
+        }
+
+        given("checkIn과 CheckOut으로 search()시") {
+            `when`("두 날짜의 범위에 reservation이 없으면") {
+                then("반환되는 Space가 있어야 한다") {
+                    val guest = membersRepository.saveAndFlush(defaultGuest)
+                    val host = membersRepository.saveAndFlush(defaultHost)
+
+                    val spaceFixture =
+                        generateSpaceFixtures(numberOfFixtures = 1, host = host, status = SpaceStatus.ACTIVE)
+                    val space = spaceRepository.saveAndFlush(spaceFixture[0])
+
+                    val baseDate = LocalDate.of(2024, 7, 1)
+
+                    val reservations = getReservationFixtures(50, guest, space, baseDate)
+                    reservationRepository.saveAllAndFlush(reservations)
+
+                    val searchResult = spaceRepository.search(
+                        sido = null,
+                        checkIn = LocalDate.of(2024, 7, 3),
+                        checkOut = LocalDate.of(2024, 7, 4),
+                        headCount = null,
+                        pageable = defaultPageable
+                    )
+                    val (contents, totalCount) = searchResult
+                    contents.size shouldNotBe 0
+                }
+            }
+
+            `when`("두 날짜의 범위에 reservation이 있으면") {
+                then("반환되는 Space가 없어야 한다") {
+                    val guest = membersRepository.saveAndFlush(defaultGuest)
+                    val host = membersRepository.saveAndFlush(defaultHost)
+
+                    val spaceFixture =
+                        generateSpaceFixtures(numberOfFixtures = 1, host = host, status = SpaceStatus.ACTIVE)
+                    val space = spaceRepository.saveAndFlush(spaceFixture[0])
+
+                    val baseDate = LocalDate.of(2024, 7, 1)
+
+                    val reservations = getReservationFixtures(50, guest, space, baseDate)
+                    reservationRepository.saveAllAndFlush(reservations)
+
+                    val searchResult = spaceRepository.search(
+                        sido = null,
+                        checkIn = LocalDate.of(2024, 7, 1),
+                        checkOut = LocalDate.of(2024, 7, 4),
+                        headCount = null,
+                        pageable = defaultPageable
+                    )
+                    val (contents, totalCount) = searchResult
+                    contents.size shouldBe 0
+                }
+            }
+        }
+
+        given("pageable외에 다른 조건이 없을 때") {
+            `when`("pageSize를 특정 값으로 지정 후 serach()시") {
+                then("pageSize만큼의 Space가 반환되고 totalCount는 space의 총 개수가 반환된다.") {
+
+                    val totalSpaceCount = 50
+                    val pageSize = 12
+
+                    val host = membersRepository.saveAndFlush(defaultHost)
+
+                    val spaceFixture = generateSpaceFixtures(
+                        numberOfFixtures = totalSpaceCount,
+                        host = host,
+                        status = SpaceStatus.ACTIVE
+                    )
+                    spaceRepository.saveAllAndFlush(spaceFixture)
+
+                    val pageable = PageRequest.of(0, pageSize)
+
+                    val searchResult = spaceRepository.search(
+                        sido = null,
+                        checkIn = null,
+                        checkOut = null,
+                        headCount = null,
+                        pageable = pageable
+                    )
+                    val (contents, totalCount) = searchResult
+
+                    contents.size shouldBe pageSize
+                    totalCount shouldBe totalSpaceCount
+                }
+            }
+
+            `when`("pageCount가 다르면") {
+                then("다른 Space 목록을 반환한다.") {
+                    val host = membersRepository.saveAndFlush(defaultHost)
+
+                    val spaceFixture =
+                        generateSpaceFixtures(numberOfFixtures = 50, host = host, status = SpaceStatus.ACTIVE)
+                    spaceRepository.saveAllAndFlush(spaceFixture)
+
+                    val page1 = PageRequest.of(0, 12)
+                    val page2 = PageRequest.of(1, 12)
+
+                    val searchResultOfPage1 = spaceRepository.search(
+                        sido = null,
+                        checkIn = null,
+                        checkOut = null,
+                        headCount = null,
+                        pageable = page1
+                    )
+
+                    val searchResultOfPage2 = spaceRepository.search(
+                        sido = null,
+                        checkIn = null,
+                        checkOut = null,
+                        headCount = null,
+                        pageable = page2
+                    )
+
+                    val (contents1, totalCount1) = searchResultOfPage1
+                    val (contents2, totalCount2) = searchResultOfPage2
+
+                    contents1 shouldNotContainValue contents2
+                }
+            }
+        }
+
+    }
+
+}) {
+    companion object {
+        val defaultPageable = PageRequest.of(0, 12, Sort.by(Sort.Direction.DESC, "createdAt"))
+        val fixture = kotlinFixture()
+
+        private val costFixture = fixture<Long> {
+            filter<Long> {
+                filter { it < 10000000 }
+            }
+        }
+
+        private val minFixture = fixture<Int> {
+            factory<Int> {
+                range(2..4)
+            }
+        }
+
+        private val maxFixture = fixture<Int> {
+            factory<Int> {
+                range(4..8)
+            }
+        }
+
+        private val sidoFixture = fixture(listOf("사울특별시", "경기도", "제주도", "충청북도", "충청남도"))
+
+        val defaultGuest = fixture<Member> {
+            property(Member::role) { MemberRole.MEMBER }
+        }
+
+        val defaultHost = fixture<Member> {
+            property(Member::role) { MemberRole.HOST }
+        }
+
+        fun generateSpaceFixtures(numberOfFixtures: Int, host: Member, status: SpaceStatus): List<Space> {
+            return (1..numberOfFixtures).map {
+                fixture<Space> {
+                    property(Address::sido) { sidoFixture }
+                    property(Space::defaultPeople) { minFixture }
+                    property(Space::maxPeople) { maxFixture }
+                    property(Space::status) { SpaceStatus.ACTIVE }
+                    property(Space::host) { host }
+                }
+            }
+        }
+
+        fun getReservationFixtures(
+            numberOfFixtures: Int,
+            guest: Member,
+            space: Space,
+            baseDate: LocalDate
+        ): List<Reservation> {
+            return (1..numberOfFixtures).map { i ->
+
+                val checkIn = baseDate.plusDays((i - 1) * 4L) // 매번 4일씩 뒤로 설정
+                val checkOut = checkIn.plusDays(2) // checkIn 2일 뒤 체크아웃
+
+                fixture<Reservation> {
+                    property(Reservation::cost) { costFixture }
+                    property(Reservation::checkIn) { checkIn }
+                    property(Reservation::checkOut) { checkOut }
+                    property(Reservation::reservationPeople) { 2 }
+                    property(Reservation::member) { guest }
+                    property(Reservation::space) { space }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 요약

SpaceQueryDslRepository.search() 테스트코드 추가

## 작업 사항
- ➕테스트 관련 의존성 추가
  - kotest-extensions-spring
  - kotlinfixture

- SpaceQueryDslRepository.search() 테스트코드 추가
  - 공간 목록 조회를 위해 querydsl로 작성한 쿼리에 대한 테스트 코드를 작성했습니다.
    -  `ACTIVE` 상태의 Space만 조회
    -  `sido`로 search()시 Space.adress.sido가 키워드를 포함한 Space만 조회
    - `checkIn`과 `checkOut` 이 예약되어있는 날짜와 겹치지 않는 Space만 조회
    - `defaultPeople <= headCount <= maxPeople`를 만족하는 Space민 조회
    - pagination 확인


## 리뷰 요청 사항

추가해야 될 테스트 케이스나 작성된 코드에 빈 곳이 없는지 확인부탁드립니다.

---

### 해결한 이슈

closes: #64
