### PR TITLE
:bug: S3 이미지 버그 수정

### DIFF
--- a/src/main/kotlin/com/beanspace/beanspace/api/image/ImageService.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/image/ImageService.kt
@@ -23,7 +23,13 @@ class ImageService(
     val s3Service: S3Service
 ) {
     fun generatePreSignedUrl(request: PreSignedUrlRequest): PreSignedUrlResponse {
-        val preSignedUrl = s3Service.generatePreSignedUrl(request.fileName, request.contentType, ImageType.SPACE)
+        val imageType = when (request.imageType) {
+            "REVIEW" -> ImageType.REVIEW
+            "SPACE" -> ImageType.SPACE
+            "PROFILE" -> ImageType.PROFILE
+            else -> throw IllegalArgumentException("이미지 타입을 올바르게 입력해주세요")
+        }
+        val preSignedUrl = s3Service.generatePreSignedUrl(request.fileName, request.contentType, imageType)
         return PreSignedUrlResponse(preSignedUrl)
     }
 

--- a/src/main/kotlin/com/beanspace/beanspace/api/image/dto/PreSignedUrlRequest.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/image/dto/PreSignedUrlRequest.kt
@@ -2,5 +2,6 @@ package com.beanspace.beanspace.api.image.dto
 
 data class PreSignedUrlRequest(
     val fileName: String,
-    val contentType: String
+    val contentType: String,
+    val imageType: String
 )

--- a/src/main/kotlin/com/beanspace/beanspace/domain/image/model/ImageType.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/image/model/ImageType.kt
@@ -1,5 +1,5 @@
 package com.beanspace.beanspace.domain.image.model
 
 enum class ImageType {
-    REVIEW, SPACE
+    REVIEW, SPACE, PROFILE
 }

--- a/src/main/kotlin/com/beanspace/beanspace/infra/s3/S3Service.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/infra/s3/S3Service.kt
@@ -32,6 +32,7 @@ class S3Service(
         val directory = when (imageType) {
             ImageType.REVIEW -> "reviews"
             ImageType.SPACE -> "spaces"
+            ImageType.PROFILE -> "profile"
         }
 
         // UUID를 이용해서 파일 이름이 겹치지 않도록 함
@@ -58,8 +59,9 @@ class S3Service(
         val expiration = Date(System.currentTimeMillis() + 900000) // 15분 뒤에 URL 만료
 
         val directory = when (imageType) {
-            ImageType.REVIEW -> "reviews"
-            ImageType.SPACE -> "spaces"
+            ImageType.REVIEW -> "review"
+            ImageType.SPACE -> "space"
+            ImageType.PROFILE -> "profile"
         }
 
         val filename = "${UUID.randomUUID()}-${fileName}"

--- a/src/main/kotlin/com/beanspace/beanspace/infra/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/infra/security/config/SecurityConfig.kt
@@ -52,7 +52,8 @@ class SecurityConfig(
                         "/api/v1/auth/login",
                         "/error",
                         "/api/v1/spaces/**",
-                        "/oauth2/login/**"
+                        "/oauth2/login/**",
+                        "api/v1/images/presigned-url"
                     ).permitAll()
                     .requestMatchers(PathRequest.toH2Console()).permitAll()
                     .anyRequest().authenticated()


### PR DESCRIPTION
## 요약

이미지 업로드시에 발생하는 버그들을 해결했습니다

## 작업 사항

ImageType ENUM에 PROFILE 추가
Spring Security에 의해 PresignedUrl 요청이 인증 필요 없도록 변경
PresignedUrl 요청시에 클라이언트가 ImageType을 같이 보내주도록 수정

---

### 해결한 이슈

closes: #67 
