### PR TITLE
✨ 소셜 회원가입 회원 추가 정보 받도록 처리

### DIFF
--- a/src/main/kotlin/com/beanspace/beanspace/api/member/MemberController.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/member/MemberController.kt
@@ -5,12 +5,18 @@ import com.beanspace.beanspace.api.coupon.dto.UserCouponResponse
 import com.beanspace.beanspace.api.member.dto.MemberProfileResponse
 import com.beanspace.beanspace.api.member.dto.MemberReservationResponse
 import com.beanspace.beanspace.api.member.dto.UpdateProfileRequest
+import com.beanspace.beanspace.api.member.dto.UpdateSocialUserInfoRequest
 import com.beanspace.beanspace.api.space.dto.WishListedSpaceResponse
 import com.beanspace.beanspace.infra.security.dto.UserPrincipal
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1/members")
@@ -62,5 +68,15 @@ class MemberController(
     fun getMemberCouponList(@AuthenticationPrincipal userPrincipal: UserPrincipal): ResponseEntity<List<UserCouponResponse>> {
         return ResponseEntity
             .ok(memberService.getCouponList(userPrincipal))
+    }
+
+    @PostMapping("/social-profile")
+    fun updateSocialUserInfo(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @Valid @RequestBody request: UpdateSocialUserInfoRequest
+    ): ResponseEntity<MemberProfileResponse> {
+        return ResponseEntity
+            .ok()
+            .body(memberService.updateSocialUserInfo(principal, request))
     }
 }

--- a/src/main/kotlin/com/beanspace/beanspace/api/member/dto/MemberProfileResponse.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/member/dto/MemberProfileResponse.kt
@@ -7,7 +7,8 @@ data class MemberProfileResponse(
     val email: String,
     val role: String,
     val nickname: String,
-    val profileImageUrl: String?
+    val profileImageUrl: String?,
+    val isPhoneNumberEmpty: Boolean
 ) {
     companion object {
         fun fromEntity(member: Member): MemberProfileResponse {
@@ -16,7 +17,8 @@ data class MemberProfileResponse(
                 email = member.email,
                 role = member.role.name,
                 nickname = member.nickname,
-                profileImageUrl = member.profileImageUrl
+                profileImageUrl = member.profileImageUrl,
+                isPhoneNumberEmpty = member.isPhoneNumberEmpty()
             )
         }
     }

--- a/src/main/kotlin/com/beanspace/beanspace/api/member/dto/UpdateSocialUserInfoRequest.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/member/dto/UpdateSocialUserInfoRequest.kt
@@ -1,0 +1,19 @@
+package com.beanspace.beanspace.api.member.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+data class UpdateSocialUserInfoRequest(
+    @field:NotBlank(message = "휴대폰 번호를 입력해주세요.")
+    @field:Pattern(
+        regexp = "^010\\d{8}\$",
+        message = "휴대폰 번호는 010으로 시작해서 11자로 설정해야합니다."
+    )
+    val phoneNumber: String,
+    @field:NotBlank(message = "이메일을 입력해주세요.")
+    @field:Pattern(
+        regexp = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$",
+        message = "올바른 이메일 형식을 입력해주세요."
+    )
+    val email: String
+)

--- a/src/main/kotlin/com/beanspace/beanspace/api/reservation/ReservationService.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/reservation/ReservationService.kt
@@ -44,7 +44,9 @@ class ReservationService(
                     ?: throw ModelNotFoundException("공간", spaceId)
 
                 val guest = memberRepository.findByIdOrNull(guestId)
-                    ?: throw ModelNotFoundException("사용자", guestId)
+                    ?.also {
+                        check(it.phoneNumber != "EMPTY") { throw IllegalStateException("전화번호를 입력하지 않은 회원은 예약이 불가능합니다.") }
+                    } ?: throw ModelNotFoundException("사용자", guestId)
 
                 val userCoupon = request.userCouponId?.let {
                     val couponKey = "userCoupon:$it"

--- a/src/main/kotlin/com/beanspace/beanspace/domain/member/model/Member.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/member/model/Member.kt
@@ -13,7 +13,7 @@ import jakarta.persistence.Id
 class Member(
 
     @Column
-    val phoneNumber: String,
+    var phoneNumber: String,
 
     @Column
     var password: String,
@@ -51,4 +51,13 @@ class Member(
     fun updateRoleToHost() {
         this.role = MemberRole.HOST
     }
+
+    fun updateSocialUserInfo(phoneNumber: String, email: String) {
+        this.phoneNumber = phoneNumber
+        this.email = email
+    }
+
+    fun isSocialUser() = providerId != null
+
+    fun isPhoneNumberEmpty() = phoneNumber == "EMPTY"
 }

--- a/src/test/kotlin/com/beanspace/beanspace/api/reservation/ReservationServiceTest.kt
+++ b/src/test/kotlin/com/beanspace/beanspace/api/reservation/ReservationServiceTest.kt
@@ -72,7 +72,10 @@ class ReservationServiceTest : BehaviorSpec({
         given("예약하려는 공간이") {
             `when`("예약자가 제공하는 공간이면") {
                 then("IllegalArgumentException 발생") {
-                    val guest = mockk<Member> { every { id } returns 1L }
+                    val guest = mockk<Member> {
+                        every { id } returns 1L
+                        every { phoneNumber } returns "01000000000"
+                    }
                     val space = mockk<Space> {
                         every { id } returns 1L
                         every { host } returns guest
@@ -92,7 +95,10 @@ class ReservationServiceTest : BehaviorSpec({
         given("체크인 날짜가") {
             `when`("당일이면") {
                 then("IllegalArgumentException 발생") {
-                    val guest = mockk<Member> { every { id } returns 1L }
+                    val guest = mockk<Member> {
+                        every { id } returns 1L
+                        every { phoneNumber } returns "01000000000"
+                    }
                     val space = mockk<Space> {
                         every { id } returns 1L
                         every { host } returns mockk<Member> { every { id } returns 2L }
@@ -116,7 +122,10 @@ class ReservationServiceTest : BehaviorSpec({
         given("체크아웃 날짜가") {
             `when`("체크인 날짜 이전이면") {
                 then("IllegalArgumentException 발생") {
-                    val guest = mockk<Member> { every { id } returns 1L }
+                    val guest = mockk<Member> {
+                        every { id } returns 1L
+                        every { phoneNumber } returns "01000000000"
+                    }
                     val space = mockk<Space> {
                         every { id } returns 1L
                         every { host } returns mockk<Member> { every { id } returns 2L }
@@ -138,7 +147,10 @@ class ReservationServiceTest : BehaviorSpec({
 
             `when`("당일로부터 6개월 이후면") {
                 then("IllegalArgumentException 발생") {
-                    val guest = mockk<Member> { every { id } returns 1L }
+                    val guest = mockk<Member> {
+                        every { id } returns 1L
+                        every { phoneNumber } returns "01000000000"
+                    }
                     val space = mockk<Space> {
                         every { id } returns 1L
                         every { host } returns mockk<Member> { every { id } returns 2L }
@@ -162,7 +174,10 @@ class ReservationServiceTest : BehaviorSpec({
         given("예약하려는 날짜가") {
             `when`("이미 예약이 되어있으면") {
                 then("IllegalArgumentException 발생") {
-                    val guest = mockk<Member> { every { id } returns 1L }
+                    val guest = mockk<Member> {
+                        every { id } returns 1L
+                        every { phoneNumber } returns "01000000000"
+                    }
                     val space = mockk<Space> {
                         every { id } returns 1L
                         every { host } returns mockk<Member> { every { id } returns 2L }
@@ -195,7 +210,10 @@ class ReservationServiceTest : BehaviorSpec({
         given("예약인원이") {
             `when`("공간의 기본 인원수와 최대 인원수 사이가 아니면") {
                 then("IllegalArgumentException 발생") {
-                    val guest = mockk<Member> { every { id } returns 1L }
+                    val guest = mockk<Member> {
+                        every { id } returns 1L
+                        every { phoneNumber } returns "01000000000"
+                    }
 
                     val space = mockk<Space> {
                         every { id } returns 1L
@@ -223,7 +241,10 @@ class ReservationServiceTest : BehaviorSpec({
         given("사용하려는 쿠폰이") {
             `when`("이미 사용된 쿠폰이라면") {
                 then("IllegalStateException 발생") {
-                    val guest = mockk<Member> { every { id } returns 1L }
+                    val guest = mockk<Member> {
+                        every { id } returns 1L
+                        every { phoneNumber } returns "01000000000"
+                    }
                     val space = mockk<Space> { every { id } returns 1L }
                     val request = mockk<ReservationRequest> { every { userCouponId } returns 1L }
                     val userCoupon = mockk<UserCoupon> { every { isCouponUnused() } returns false }
@@ -240,7 +261,10 @@ class ReservationServiceTest : BehaviorSpec({
 
             `when`("유효기간이 지난 쿠폰이라면") {
                 then("IllegalStateException 발생") {
-                    val guest = mockk<Member> { every { id } returns 1L }
+                    val guest = mockk<Member> {
+                        every { id } returns 1L
+                        every { phoneNumber } returns "01000000000"
+                    }
                     val space = mockk<Space> { every { id } returns 1L }
                     val request = mockk<ReservationRequest> { every { userCouponId } returns 1L }
                     val userCoupon = mockk<UserCoupon> {
@@ -264,7 +288,10 @@ class ReservationServiceTest : BehaviorSpec({
         given("기본인원: 2명, 기본 요금: 30000원, 추가요금: 10000원인 공간을 4명이 2박을 예약할때") {
             `when`("적용한 쿠폰이 없다면") {
                 then("결제금액은 (30000 + 10000 x 2) x 2 = 100000원 이어야한다.") {
-                    val guest = mockk<Member> { every { id } returns 1L }
+                    val guest = mockk<Member> {
+                        every { id } returns 1L
+                        every { phoneNumber } returns "01000000000"
+                    }
 
                     val space = mockk<Space> {
                         every { id } returns 1L
@@ -317,7 +344,10 @@ class ReservationServiceTest : BehaviorSpec({
 
             `when`("할인율이 30%, 최대할인 금액이 40000원인 쿠폰을 적용하면") {
                 then("결제금액은 100000 - 30000 = 70000원 이어야 한다.") {
-                    val guest = mockk<Member> { every { id } returns 1L }
+                    val guest = mockk<Member> {
+                        every { id } returns 1L
+                        every { phoneNumber } returns "01000000000"
+                    }
 
                     val space = mockk<Space> {
                         every { id } returns 1L
@@ -381,7 +411,10 @@ class ReservationServiceTest : BehaviorSpec({
 
             `when`("할인율이 30%, 최대 할인 금액이 20000원인 쿠폰을 적용하면") {
                 then("결제금액은 100000 - 20000 = 80000원 이어야한다.") {
-                    val guest = mockk<Member> { every { id } returns 1L }
+                    val guest = mockk<Member> {
+                        every { id } returns 1L
+                        every { phoneNumber } returns "01000000000"
+                    }
 
                     val space = mockk<Space> {
                         every { id } returns 1L


### PR DESCRIPTION
## 요약

소셜 회원가입 회원 추가 정보를 추가로 받도록 처리하였습니다

## 작업 사항

- 소셜 회원가입 회원 추가 정보를 받을 수 있는 API를 추가하였습니다.
- 전화번호가 없는 멤버가 예약을 할 수 없도록 만들었습니다.

---

### 해결한 이슈

closes: #104
