### PR TITLE
:sparkles: 공간 목록, 개별 조회시 상세주소가 노출되지 않게 수정

### DIFF
--- a/src/main/kotlin/com/beanspace/beanspace/api/space/SpaceController.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/space/SpaceController.kt
@@ -3,7 +3,7 @@ package com.beanspace.beanspace.api.space
 import com.beanspace.beanspace.api.space.dto.AddReviewRequest
 import com.beanspace.beanspace.api.space.dto.ReviewResponse
 import com.beanspace.beanspace.api.space.dto.SpaceDetailResponse
-import com.beanspace.beanspace.api.space.dto.SpaceResponse
+import com.beanspace.beanspace.api.space.dto.SpaceResponseWithoutAddress
 import com.beanspace.beanspace.api.space.dto.UpdateReviewRequest
 import com.beanspace.beanspace.infra.security.dto.UserPrincipal
 import org.springframework.data.domain.Page
@@ -36,7 +36,7 @@ class SpaceController(private val spaceService: SpaceService) {
         @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") checkOut: LocalDate?,
         @RequestParam(required = false) headCount: Int?,
         @PageableDefault(page = 0, size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
-    ): ResponseEntity<Page<SpaceResponse>> {
+    ): ResponseEntity<Page<SpaceResponseWithoutAddress>> {
         return ResponseEntity.ok(
             spaceService.getSpaceList(
                 sido = sido,

--- a/src/main/kotlin/com/beanspace/beanspace/api/space/SpaceService.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/space/SpaceService.kt
@@ -4,7 +4,7 @@ import com.beanspace.beanspace.api.space.dto.AddReviewRequest
 import com.beanspace.beanspace.api.space.dto.HostResponse
 import com.beanspace.beanspace.api.space.dto.ReviewResponse
 import com.beanspace.beanspace.api.space.dto.SpaceDetailResponse
-import com.beanspace.beanspace.api.space.dto.SpaceResponse
+import com.beanspace.beanspace.api.space.dto.SpaceResponseWithoutAddress
 import com.beanspace.beanspace.api.space.dto.UpdateReviewRequest
 import com.beanspace.beanspace.domain.exception.ModelNotFoundException
 import com.beanspace.beanspace.domain.exception.NoPermissionException
@@ -43,7 +43,7 @@ class SpaceService(
         checkOut: LocalDate?,
         headCount: Int?,
         pageable: Pageable
-    ): Page<SpaceResponse> {
+    ): Page<SpaceResponseWithoutAddress> {
         val (contents, totalCount) = spaceRepository.search(
             sido = sido,
             checkIn = checkIn,
@@ -55,7 +55,7 @@ class SpaceService(
         if (contents.isEmpty() || totalCount == 0L) {
             return Page.empty()
         }
-        val response = contents.map { SpaceResponse.from(it.key!!, it.value) }
+        val response = contents.map { SpaceResponseWithoutAddress.from(it.key!!, it.value) }
 
         return PageImpl(response, pageable, totalCount)
     }
@@ -75,7 +75,7 @@ class SpaceService(
         ).flatMap { it.checkIn.datesUntil(it.checkOut).toList() }.filter { it.isAfter(today) }
 
         return SpaceDetailResponse.from(
-            spaceResponse = SpaceResponse.from(space, spaceImageList.map { it.imageUrl }),
+            spaceResponseWithoutAddress = SpaceResponseWithoutAddress.from(space, spaceImageList.map { it.imageUrl }),
             averageRating = averageRating,
             hostResponse = HostResponse(
                 nickname = space.host.nickname,

--- a/src/main/kotlin/com/beanspace/beanspace/api/space/dto/SpaceDetailResponse.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/space/dto/SpaceDetailResponse.kt
@@ -3,20 +3,20 @@ package com.beanspace.beanspace.api.space.dto
 import java.time.LocalDate
 
 data class SpaceDetailResponse(
-    val space: SpaceResponse,
+    val space: SpaceResponseWithoutAddress,
     val averageRating: Double,
     val host: HostResponse,
     val reservedDateList: List<LocalDate>,
 ) {
     companion object {
         fun from(
-            spaceResponse: SpaceResponse,
+            spaceResponseWithoutAddress: SpaceResponseWithoutAddress,
             averageRating: Double,
             hostResponse: HostResponse,
             reservedDateList: List<LocalDate>,
         ): SpaceDetailResponse {
             return SpaceDetailResponse(
-                space = spaceResponse,
+                space = spaceResponseWithoutAddress,
                 averageRating = averageRating,
                 host = hostResponse,
                 reservedDateList = reservedDateList

--- a/src/main/kotlin/com/beanspace/beanspace/api/space/dto/SpaceResponseWithoutAddress.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/space/dto/SpaceResponseWithoutAddress.kt
@@ -1,0 +1,43 @@
+package com.beanspace.beanspace.api.space.dto
+
+import com.beanspace.beanspace.domain.space.model.Space
+import com.beanspace.beanspace.domain.space.model.SpaceStatus
+
+data class SpaceResponseWithoutAddress(
+    val id: Long,
+    val listingName: String,
+    val price: Int,
+    val sido: String,
+    val content: String,
+    val defaultPeople: Int,
+    val maxPeople: Int,
+    val pricePerPerson: Int,
+    val bedRoomCount: Int,
+    val bedCount: Int,
+    val bathRoomCount: Int,
+    val status: SpaceStatus,
+    val imageUrlList: List<String>
+) {
+    companion object {
+        fun from(
+            space: Space,
+            imageUrlList: List<String>,
+        ): SpaceResponseWithoutAddress {
+            return SpaceResponseWithoutAddress(
+                id = space.id!!,
+                listingName = space.listingName,
+                price = space.price,
+                sido = space.address.sido,
+                content = space.content,
+                defaultPeople = space.defaultPeople,
+                maxPeople = space.maxPeople,
+                pricePerPerson = space.pricePerPerson,
+                bedRoomCount = space.bedRoomCount,
+                bedCount = space.bedCount,
+                bathRoomCount = space.bathRoomCount,
+                status = space.status,
+                imageUrlList = imageUrlList
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 요약

공간 조회 시 SpaceResponse를 통해 상세 주소가 노출되는 문제를 해결

## 작업 사항

SpaceResponseWithoutAddress를 만들어 상세주소가 없는 Response를 목록, 상세 조회시 출력하도록 수정

Host 자신의 공간 목록 조회시 - 상세 주소 포함(우편번호, 도로명주소, 상세주소)

Member가 공간 상세 페이지 및 공간 목록 조회시 - 상세 주소 미포함

---

### 해결한 이슈

closes: #91 
