### PR TITLE
:sparkles: 프로필 수정, 소셜 로그인 유저 정보 추가시 받는 정보 수정

### DIFF
--- a/src/main/kotlin/com/beanspace/beanspace/api/member/MemberService.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/member/MemberService.kt
@@ -103,7 +103,7 @@ class MemberService(
         return memberRepository.findByIdOrNull(principal.id)
             ?.also { check(it.isSocialUser()) { throw NoPermissionException("소셜 유저가 아닙니다!") } }
             ?.also { check(it.isPhoneNumberEmpty()) { throw IllegalStateException("이미 전화번호가 있습니다") } }
-            ?.also { it.updateSocialUserInfo(request.phoneNumber, request.email) }
+            ?.also { it.updateSocialUserInfo(request.phoneNumber) }
             ?.let { MemberProfileResponse.fromEntity(it) }
             ?: throw ModelNotFoundException("Member", principal.id)
     }

--- a/src/main/kotlin/com/beanspace/beanspace/api/member/dto/UpdateProfileRequest.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/member/dto/UpdateProfileRequest.kt
@@ -16,7 +16,7 @@ data class UpdateProfileRequest(
 
     @field:NotBlank(message = "이메일을 입력해주세요.")
     @field:Pattern(
-        regexp = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$",
+        regexp = "(^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$|^EMPTY$)",
         message = "올바른 이메일 형식을 입력해주세요."
     )
     val email: String,

--- a/src/main/kotlin/com/beanspace/beanspace/api/member/dto/UpdateSocialUserInfoRequest.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/member/dto/UpdateSocialUserInfoRequest.kt
@@ -9,11 +9,5 @@ data class UpdateSocialUserInfoRequest(
         regexp = "^010\\d{8}\$",
         message = "휴대폰 번호는 010으로 시작해서 11자로 설정해야합니다."
     )
-    val phoneNumber: String,
-    @field:NotBlank(message = "이메일을 입력해주세요.")
-    @field:Pattern(
-        regexp = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$",
-        message = "올바른 이메일 형식을 입력해주세요."
-    )
-    val email: String
+    val phoneNumber: String
 )

--- a/src/main/kotlin/com/beanspace/beanspace/domain/member/model/Member.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/member/model/Member.kt
@@ -52,9 +52,8 @@ class Member(
         this.role = MemberRole.HOST
     }
 
-    fun updateSocialUserInfo(phoneNumber: String, email: String) {
+    fun updateSocialUserInfo(phoneNumber: String) {
         this.phoneNumber = phoneNumber
-        this.email = email
     }
 
     fun isSocialUser() = providerId != null


### PR DESCRIPTION
## 요약

프로필 수정, 소셜 로그인 유저 정보 추가시 받는 정보를 수정하였습니다

## 작업 사항

 - 프로필 수정 시, 사용자가 반드시 이메일을 넣지 않아도 되도록 수정합니다
 - 소셜 로그인 유저의 추가 정보를 전화번호만 받도록 수정합니다

---

### 해결한 이슈

closes: #130 
