### PR TITLE
🐛 SpaceQueryDslRepository 쿼리 오류 수정

### DIFF
--- a/src/main/kotlin/com/beanspace/beanspace/domain/space/repository/SpaceQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/space/repository/SpaceQueryDslRepositoryImpl.kt
@@ -168,13 +168,14 @@ class SpaceQueryDslRepositoryImpl(
 
             else -> {
                 val paginatedSpaceId = queryFactory
-                    .select(space.id).distinct()
+                    .select(space).distinct()
                     .from(space)
                     .where(conditions)
                     .offset(pageable.offset)
                     .limit(pageable.pageSize.toLong())
                     .orderBy(getOrderSpecifier(pageable, space))
                     .fetch()
+                    .map { it.id }
 
                 queryFactory.select(space, image, review.rating.avg().`as`(rating))
                     .from(space)


### PR DESCRIPTION
## 요약

SpaceQueryDslRepository 쿼리 오류 수정

## 작업 사항

- `getMostPopular4SpaceList()`: 인기 상위 4개 공간의 순서가 보장되지 않는 문제 수정
-  `search()`: 정렬 오류 수정

---

### 해결한 이슈

closes: #145 
