### PR TITLE
✨ 인기 공간 불러오기에 캐시 적용

### DIFF
--- a/src/main/kotlin/com/beanspace/beanspace/BeanSpaceApplication.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/BeanSpaceApplication.kt
@@ -3,10 +3,12 @@ package com.beanspace.beanspace
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableScheduling
 import java.time.ZoneId
 import java.util.TimeZone
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 class BeanSpaceApplication
 

--- a/src/main/kotlin/com/beanspace/beanspace/api/space/SpaceService.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/space/SpaceService.kt
@@ -26,6 +26,7 @@ import com.beanspace.beanspace.domain.space.repository.SpaceOfferRepository
 import com.beanspace.beanspace.domain.space.repository.SpaceRepository
 import com.beanspace.beanspace.domain.space.repository.WishListRepository
 import com.beanspace.beanspace.infra.security.dto.UserPrincipal
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -238,6 +239,7 @@ class SpaceService(
         return PopularKeywordsResponse(searchKeywordRepository.getPopularKeywords(oneDayBefore, now))
     }
 
+    @Cacheable(cacheNames = ["popularSpace"], key = "'lastWeek'")
     fun getPopularSpacesLastWeek(): List<CompactSpaceResponse> {
         return spaceRepository.getMostPopular4SpaceList()
             .map { CompactSpaceResponse.fromEntity(it.key!!, it.value) }

--- a/src/main/kotlin/com/beanspace/beanspace/api/space/SpaceService.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/space/SpaceService.kt
@@ -26,11 +26,14 @@ import com.beanspace.beanspace.domain.space.repository.SpaceOfferRepository
 import com.beanspace.beanspace.domain.space.repository.SpaceRepository
 import com.beanspace.beanspace.domain.space.repository.WishListRepository
 import com.beanspace.beanspace.infra.security.dto.UserPrincipal
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.cache.annotation.CachePut
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.text.DecimalFormat
@@ -49,6 +52,9 @@ class SpaceService(
     private val spaceOfferRepository: SpaceOfferRepository,
     private val offerRepository: OfferRepository
 ) {
+
+    private val log = KotlinLogging.logger {}
+
     fun getSpaceList(
         keyword: String?,
         checkIn: LocalDate?,
@@ -239,8 +245,19 @@ class SpaceService(
         return PopularKeywordsResponse(searchKeywordRepository.getPopularKeywords(oneDayBefore, now))
     }
 
-    @Cacheable(cacheNames = ["popularSpace"], key = "'lastWeek'")
+    @Cacheable("popularSpace", key = "'lastWeek'")
     fun getPopularSpacesLastWeek(): List<CompactSpaceResponse> {
+        return fetchPopularSpaces()
+    }
+
+    @Scheduled(cron = "0 43 19 * * *")
+    @CachePut("popularSpace", key = "'lastWeek'")
+    fun updatePopularSpacesCache(): List<CompactSpaceResponse> {
+        log.info { "key:'popularSpace::lastWeek', 최근 일주일 예약 많은 공간 TOP4 내역이 업데이트 되었습니다!" }
+        return fetchPopularSpaces()
+    }
+
+    private fun fetchPopularSpaces(): List<CompactSpaceResponse> {
         return spaceRepository.getMostPopular4SpaceList()
             .map { CompactSpaceResponse.fromEntity(it.key!!, it.value) }
     }

--- a/src/main/kotlin/com/beanspace/beanspace/api/space/SpaceService.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/space/SpaceService.kt
@@ -250,10 +250,10 @@ class SpaceService(
         return fetchPopularSpaces()
     }
 
-    @Scheduled(cron = "0 43 19 * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     @CachePut("popularSpace", key = "'lastWeek'")
     fun updatePopularSpacesCache(): List<CompactSpaceResponse> {
-        log.info { "key:'popularSpace::lastWeek', 최근 일주일 예약 많은 공간 TOP4 내역이 업데이트 되었습니다!" }
+        log.info { "Redis key:'popularSpace::lastWeek', 최근 일주일 예약 많은 공간 TOP4 내역이 업데이트 되었습니다!" }
         return fetchPopularSpaces()
     }
 

--- a/src/main/kotlin/com/beanspace/beanspace/api/space/dto/CompactSpaceResponse.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/space/dto/CompactSpaceResponse.kt
@@ -1,6 +1,7 @@
 package com.beanspace.beanspace.api.space.dto
 
 import com.beanspace.beanspace.domain.space.model.Space
+import java.io.Serializable
 
 data class CompactSpaceResponse(
     val spaceId: Long,
@@ -9,7 +10,7 @@ data class CompactSpaceResponse(
     val defaultPeople: Int,
     val sidoAndSigungu: String,
     val imageUrlList: List<String>
-) {
+) : Serializable {
     companion object {
         fun fromEntity(space: Space, imageUrlList: List<String>): CompactSpaceResponse {
             return CompactSpaceResponse(

--- a/src/main/kotlin/com/beanspace/beanspace/infra/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/infra/redis/RedisConfig.kt
@@ -47,13 +47,21 @@ class RedisConfig(
         return Redisson.create(config)
     }
 
-    @Bean()
-    fun redisCacheManager(): CacheManager {
-
+    @Bean
+    fun redisCacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
         val redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
-            .entryTtl(Duration.ofMinutes(60))
+            .entryTtl(Duration.ofDays(3))
 
-        return RedisCacheManager.builder(redisConnectionFactory())
-            .cacheDefaults(redisCacheConfiguration).build()
+        val cacheConfigurations = mapOf(
+            "popularSpace" to RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofDays(3))
+                .disableCachingNullValues()
+        )
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+            .cacheDefaults(redisCacheConfiguration)
+            .withInitialCacheConfigurations(cacheConfigurations)
+            .transactionAware()
+            .build()
     }
 }

--- a/src/main/kotlin/com/beanspace/beanspace/infra/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/infra/redis/RedisConfig.kt
@@ -4,15 +4,21 @@ import org.redisson.Redisson
 import org.redisson.api.RedissonClient
 import org.redisson.config.Config
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
 
 @Profile("!test")
+@EnableCaching
 @Configuration
 class RedisConfig(
     @Value("\${spring.data.redis.host}") private val host: String,
@@ -28,7 +34,6 @@ class RedisConfig(
     fun redisTemplate(redisConnectionFactory: RedisConnectionFactory): RedisTemplate<String, String> {
         val template = RedisTemplate<String, String>()
         template.connectionFactory = redisConnectionFactory
-
         template.keySerializer = StringRedisSerializer()
         template.valueSerializer = StringRedisSerializer()
 
@@ -40,5 +45,15 @@ class RedisConfig(
         val config = Config()
         config.useSingleServer().address = "redis://${host}:${port}"
         return Redisson.create(config)
+    }
+
+    @Bean()
+    fun redisCacheManager(): CacheManager {
+
+        val redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(60))
+
+        return RedisCacheManager.builder(redisConnectionFactory())
+            .cacheDefaults(redisCacheConfiguration).build()
     }
 }


### PR DESCRIPTION
## 요약

가장 예약이 많은 공간 TOP 4 불러올 때 캐시를 적용하도록 만들었습니다

## 작업 사항

- 일주일간 가장 예약이 많은 공간 TOP4 정보를 불러올 때 캐시를 이용합니다
- 캐시는 자정마다 업데이트 됩니다

---

### 해결한 이슈

closes: #152 
