### PR TITLE
:sparkles: 오래된 검색어 정리 (스케줄러 설정)

### DIFF
--- a/src/main/kotlin/com/beanspace/beanspace/api/admin/AdminController.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/admin/AdminController.kt
@@ -10,16 +10,7 @@ import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PatchMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @PreAuthorize("hasAnyRole('ADMIN')")
 @RestController
@@ -65,4 +56,11 @@ class AdminController(private val adminService: AdminService) {
         adminService.deleteCoupon(couponId)
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
+
+    @DeleteMapping("/old-keywords")
+    fun deleteOldKeywords(): ResponseEntity<Unit> {
+        adminService.deleteOldKeywords()
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+    }
+
 }

--- a/src/main/kotlin/com/beanspace/beanspace/api/admin/AdminService.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/api/admin/AdminService.kt
@@ -7,11 +7,13 @@ import com.beanspace.beanspace.api.coupon.dto.CouponResponse
 import com.beanspace.beanspace.domain.coupon.repository.CouponRepository
 import com.beanspace.beanspace.domain.exception.ModelNotFoundException
 import com.beanspace.beanspace.domain.space.model.SpaceStatus
+import com.beanspace.beanspace.domain.space.repository.SearchKeywordRepository
 import com.beanspace.beanspace.domain.space.repository.SpaceRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -19,7 +21,8 @@ import java.time.LocalDateTime
 @Service
 class AdminService(
     private val spaceRepository: SpaceRepository,
-    private val couponRepository: CouponRepository
+    private val couponRepository: CouponRepository,
+    private val searchKeywordRepository: SearchKeywordRepository,
 ) {
     fun getRequestAddSpace(pageable: Pageable, status: String): Page<RequestAddSpaceResponse> {
         val spaceStatus = when (status) {
@@ -110,6 +113,13 @@ class AdminService(
         }
 
         couponRepository.delete(coupon)
+    }
+
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    fun deleteOldKeywords() {
+        val threeDaysAgo = LocalDateTime.now().minusDays(3)
+        searchKeywordRepository.deleteByCreatedAtBefore(threeDaysAgo)
     }
 
     private fun validateRequest(request: CouponRequest) {

--- a/src/main/kotlin/com/beanspace/beanspace/domain/space/repository/SearchKeywordQueryDslRepository.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/space/repository/SearchKeywordQueryDslRepository.kt
@@ -4,4 +4,5 @@ import java.time.LocalDateTime
 
 interface SearchKeywordQueryDslRepository {
     fun getPopularKeywords(from: LocalDateTime, to: LocalDateTime): List<String>
+    fun deleteByCreatedAtBefore(dateTime: LocalDateTime)
 }

--- a/src/main/kotlin/com/beanspace/beanspace/domain/space/repository/SearchKeywordQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/beanspace/beanspace/domain/space/repository/SearchKeywordQueryDslRepositoryImpl.kt
@@ -22,4 +22,11 @@ class SearchKeywordQueryDslRepositoryImpl(
             .limit(10)
             .fetch()
     }
+
+    override fun deleteByCreatedAtBefore(dateTime: LocalDateTime) {
+        queryFactory
+            .delete(searchKeyword)
+            .where(searchKeyword.createdAt.lt(dateTime))
+            .execute()
+    }
 }

--- a/src/test/kotlin/com/beanspace/beanspace/api/admin/AdminServiceTest.kt
+++ b/src/test/kotlin/com/beanspace/beanspace/api/admin/AdminServiceTest.kt
@@ -5,6 +5,7 @@ import com.beanspace.beanspace.api.coupon.dto.CouponRequest
 import com.beanspace.beanspace.domain.coupon.repository.CouponRepository
 import com.beanspace.beanspace.domain.space.model.Space
 import com.beanspace.beanspace.domain.space.model.SpaceStatus
+import com.beanspace.beanspace.domain.space.repository.SearchKeywordRepository
 import com.beanspace.beanspace.domain.space.repository.SpaceRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -21,10 +22,12 @@ import kotlin.random.Random
 class AdminServiceTest : BehaviorSpec({
     val spaceRepository: SpaceRepository = mockk(relaxed = true)
     val couponRepository: CouponRepository = mockk(relaxed = true)
+    val searchKeywordRepository: SearchKeywordRepository = mockk(relaxed = true)
 
     val adminService = AdminService(
         spaceRepository = spaceRepository,
-        couponRepository = couponRepository
+        couponRepository = couponRepository,
+        searchKeywordRepository = searchKeywordRepository
     )
 
     afterContainer { clearAllMocks() }


### PR DESCRIPTION

## 요약

검색어 스케줄러로 주기적으로 삭제 

## 작업 사항

- AdminService : 매일 새벽 3시에 실행되도록 cron식 추가
- SearchKeywordQueryDslRepositoryImpl : 검색어를 삭제하는 메서드 (쿼리 DSL 운용 )

---

### 해결한 이슈

closes: #154 
